### PR TITLE
fix missing folders bug

### DIFF
--- a/src/scripts/posts/README.md
+++ b/src/scripts/posts/README.md
@@ -1,0 +1,11 @@
+# Posts
+Code used to generate the plots and tables used in the posts.
+
+## Usage
+
+There is a circular reference between these Python scripts. Therefore you must:
+
+1. Run `python professional_programs.py`
+2. This will crash, that's okay.
+3. Run `python baseline_and_hypothetical_programs.py`
+4. Now run `python professional_programs.py` again. It will complete successfully this time.

--- a/src/scripts/posts/baseline_and_hypothetical_programs.py
+++ b/src/scripts/posts/baseline_and_hypothetical_programs.py
@@ -8,6 +8,7 @@ Imports
 """
 
 import sys
+import os
 
 sys.path.append("src")
 
@@ -68,6 +69,8 @@ Cost-effectiveness of baseline programs
 """
 
 # Cost-effectiveness baselines
+
+os.makedirs('output/data/professional_programs', exist_ok = True)
 with open("output/data/professional_programs/df_functions.pkl", "rb") as f:
     df_functions_professional = pickle.load(f)
 

--- a/src/scripts/posts/professional_programs.py
+++ b/src/scripts/posts/professional_programs.py
@@ -8,6 +8,7 @@ Imports
 """
 
 import sys
+import os
 
 sys.path.append("src")
 
@@ -91,6 +92,7 @@ df_functions, df_params = so.get_program_data(
 )
 
 # Save data
+os.makedirs('output/data/professional_programs', exist_ok = True)
 with open("output/data/professional_programs/df_functions.pkl", "wb") as f:
     pickle.dump(df_functions, f)
 
@@ -123,6 +125,7 @@ Cost-effectiveness table
 """
 
 # Load data on hypothetical programs
+os.makedirs('output/data/baseline_and_hypothetical_programs', exist_ok = True)
 with open(
     "output/data/baseline_and_hypothetical_programs/hypothetical_programs_means.pkl",
     "rb",


### PR DESCRIPTION
The `post` scripts don't run on a clean install because some folders are missing. This PR creates them.

There is also a weird circular dependency between the baseline and professional scripts (each of them reads binary files that the other writes). Probably the correct way to fix this is to refactor the logic but I assume this isn't important enough so I just created a readme file to document the solution.